### PR TITLE
make sure npm is available in the env when building

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -60,6 +60,8 @@ prepare() {
 }
 
 build() {
+    getnvm
+
     cd "${srcdir}/${pkgname%-git}"
 
     # We are not using the systems Electron as we need castlab's Electron.


### PR DESCRIPTION
There was the proper environment missing in the build() routine when npm wasn't installed globally. This led the build fail because `npm` could not be found. Calling getnvm to source the NVM env fixes it.